### PR TITLE
Increases heap memory so that dist works out of the box

### DIFF
--- a/dcc-id-server/src/main/conf/wrapper.conf
+++ b/dcc-id-server/src/main/conf/wrapper.conf
@@ -56,7 +56,7 @@ wrapper.java.additional.5=-Djava.security.egd=file:/dev/./urandom
 #wrapper.java.initmemory=3
 
 # Maximum Java Heap Size (in MB)
-wrapper.java.maxmemory=4092
+wrapper.java.maxmemory=6144
 
 # Application parameters.  Add parameters as needed starting from 1
 wrapper.app.parameter.1=org.springframework.boot.loader.JarLauncher


### PR DESCRIPTION
Current setting is too low for base ehcache settings, so using the tarball to install will not work without modification. 

Related to dcc-cm
